### PR TITLE
Filter and fetch challenges by text

### DIFF
--- a/application/app/(app)/index.tsx
+++ b/application/app/(app)/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import React, { useState, useCallback, useEffect } from "react";
 import { Link, router } from "expo-router";
-import { UserPlus, Plus } from "lucide-react-native";
+import { UserPlus, Plus, ChevronDown } from "lucide-react-native";
 import { useSupabase } from "@/context/auth-context";
 import DerkapCard from "@/components/derkap/DerkapCard";
 import { useFocusEffect } from "@react-navigation/native";
@@ -18,7 +18,7 @@ import Toast from "react-native-toast-message";
 import Avatar from "@/components/Avatar";
 import useFriendStore from "@/store/useFriendStore";
 import { TDerkapDB } from "@/types/types";
-import { fetchDerkaps } from "@/functions/derkap-action";
+import { fetchDerkaps, fetchAllowedChallenges, fetchDerkapsByChallenge } from "@/functions/derkap-action";
 import useMyChallengesStore from "@/store/useMyChallengesStore";
 import Button from "@/components/Button";
 import Tutorial from "@/components/Tutorial";
@@ -30,6 +30,14 @@ const Home = () => {
   const [refreshing, setRefreshing] = useState(false);
   const [activeFilter, setActiveFilter] = useState<"all" | "unrevealed">("all");
   const [showTutorial, setShowTutorial] = useState(false);
+  
+  // Challenge selector state
+  const [selectedChallenge, setSelectedChallenge] = useState<string | null>(null);
+  const [availableChallenges, setAvailableChallenges] = useState<string[]>([]);
+  const [challengesLoading, setChallengesLoading] = useState(false);
+  const [showChallengeSelector, setShowChallengeSelector] = useState(false);
+  const [challengesPage, setChallengesPage] = useState(1);
+  const [hasMoreChallenges, setHasMoreChallenges] = useState(true);
 
   const { requests, fetchRequests } = useFriendStore();
   const { user, profile, fetchFriendsCount, friendsCount } = useSupabase();
@@ -40,9 +48,41 @@ const Home = () => {
   const [derkapsLoading, setDerkapsLoading] = useState(false);
   const [friendsRequestsCount, setFriendsRequestsCount] = useState(0);
 
+  // Fetch challenges function
+  const fetchChallenges = async (page: number = 1, reset: boolean = true) => {
+    try {
+      setChallengesLoading(true);
+      const { challenges, hasMore } = await fetchAllowedChallenges({ page });
+      
+      if (reset) {
+        setAvailableChallenges(challenges);
+        setChallengesPage(1);
+      } else {
+        setAvailableChallenges(prev => [...prev, ...challenges]);
+      }
+      
+      setHasMoreChallenges(hasMore);
+      if (!reset) {
+        setChallengesPage(page);
+      }
+    } catch (error) {
+      console.error("Error fetching challenges:", error);
+      Toast.show({
+        type: "error",
+        text1: "Erreur lors du chargement des défis",
+      });
+    } finally {
+      setChallengesLoading(false);
+    }
+  };
+
   const fetchMoreDerkaps = async () => {
     if (hasMoreDerkaps) {
-      await fetchDerkapsTimeline({ page: derkapsPage + 1, reset: false });
+      if (selectedChallenge) {
+        await fetchDerkapsForChallenge(selectedChallenge, derkapsPage + 1, false);
+      } else {
+        await fetchDerkapsTimeline({ page: derkapsPage + 1, reset: false });
+      }
       setDerkapsPage(derkapsPage + 1);
     }
   };
@@ -78,8 +118,44 @@ const Home = () => {
     }
   };
 
+  const fetchDerkapsForChallenge = async (challenge: string, page: number, reset: boolean) => {
+    try {
+      if (!user) {
+        return;
+      }
+      setDerkapsLoading(true);
+      const newDerkaps = await fetchDerkapsByChallenge({ challenge, page });
+      if (newDerkaps.length === 0) {
+        setHasMoreDerkaps(false);
+      } else {
+        setDerkaps(reset ? newDerkaps : [...derkaps, ...newDerkaps]);
+      }
+    } catch (error) {
+      console.error("Error fetching derkaps for challenge:", error);
+      Toast.show({
+        type: "error",
+        text1: "Erreur lors du chargement des derkaps",
+      });
+    } finally {
+      setDerkapsLoading(false);
+    }
+  };
+
   const removeDerkapLocally = (derkap_id: number) => {
     setDerkaps(derkaps.filter((derkap) => derkap.id !== derkap_id));
+  };
+
+  const handleChallengeSelect = async (challenge: string | null) => {
+    setSelectedChallenge(challenge);
+    setShowChallengeSelector(false);
+    setDerkapsPage(1);
+    setHasMoreDerkaps(true);
+    
+    if (challenge) {
+      await fetchDerkapsForChallenge(challenge, 1, true);
+    } else {
+      await fetchDerkapsTimeline({ page: 1, reset: true });
+    }
   };
 
   // Check if tutorial has been seen
@@ -106,7 +182,14 @@ const Home = () => {
       setRefreshing(true);
       await fetchFriendsCount();
       await refreshMyChallenges();
-      await fetchDerkapsTimeline({ page: 1, reset: true });
+      await fetchChallenges(1, true);
+      
+      if (selectedChallenge) {
+        await fetchDerkapsForChallenge(selectedChallenge, 1, true);
+      } else {
+        await fetchDerkapsTimeline({ page: 1, reset: true });
+      }
+      
       await fetchRequests();
       setDerkapsPage(1);
       setHasMoreDerkaps(true);
@@ -133,6 +216,60 @@ const Home = () => {
   if (showTutorial) {
     return <Tutorial onFinish={handleTutorialFinish} />;
   }
+
+  const ChallengeSelector = () => (
+    <View className="mb-4 px-4">
+      <Pressable
+        onPress={() => setShowChallengeSelector(!showChallengeSelector)}
+        className="flex-row items-center justify-between p-3 bg-gray-700 rounded"
+      >
+        <Text className="text-white flex-1 mr-2" numberOfLines={1}>
+          {selectedChallenge || "Tous les défis"}
+        </Text>
+        <ChevronDown size={20} color="white" />
+      </Pressable>
+      
+      {showChallengeSelector && (
+        <View className="mt-2 bg-gray-800 rounded max-h-48">
+          <ScrollView
+            onScrollEndDrag={({ nativeEvent }) => {
+              const { layoutMeasurement, contentOffset, contentSize } = nativeEvent;
+              const isCloseToBottom = layoutMeasurement.height + contentOffset.y >= contentSize.height - 20;
+              
+              if (isCloseToBottom && hasMoreChallenges && !challengesLoading) {
+                fetchChallenges(challengesPage + 1, false);
+              }
+            }}
+          >
+            <Pressable
+              onPress={() => handleChallengeSelect(null)}
+              className={`p-3 border-b border-gray-600 ${!selectedChallenge ? 'bg-custom-primary' : ''}`}
+            >
+              <Text className="text-white">Tous les défis</Text>
+            </Pressable>
+            
+            {availableChallenges.map((challenge, index) => (
+              <Pressable
+                key={index}
+                onPress={() => handleChallengeSelect(challenge)}
+                className={`p-3 border-b border-gray-600 ${selectedChallenge === challenge ? 'bg-custom-primary' : ''}`}
+              >
+                <Text className="text-white" numberOfLines={2}>
+                  {challenge}
+                </Text>
+              </Pressable>
+            ))}
+            
+            {challengesLoading && (
+              <View className="p-3">
+                <ActivityIndicator size="small" color="white" />
+              </View>
+            )}
+          </ScrollView>
+        </View>
+      )}
+    </View>
+  );
 
   return (
     <View className="flex-1">
@@ -162,6 +299,8 @@ const Home = () => {
           />
         </Link>
       </View>
+
+      <ChallengeSelector />
 
       <View className="flex-row justify-center px-4 mb-4 gap-x-4">
         <Pressable
@@ -237,7 +376,10 @@ const Home = () => {
           ) : (
             <View className="items-center justify-center flex-1">
               <Text className="text-center text-white">
-                Aucun derkap pour le moment
+                {selectedChallenge 
+                  ? `Aucun derkap pour le défi "${selectedChallenge}"`
+                  : "Aucun derkap pour le moment"
+                }
               </Text>
             </View>
           )}

--- a/application/supabase/migrations/20250802000000_add_get_user_allowed_challenges.sql
+++ b/application/supabase/migrations/20250802000000_add_get_user_allowed_challenges.sql
@@ -1,0 +1,29 @@
+-- Migration to add function for fetching user's allowed challenges with pagination
+
+CREATE OR REPLACE FUNCTION public.get_user_allowed_challenges(
+  p_user_id uuid,
+  p_limit integer DEFAULT 50,
+  p_offset integer DEFAULT 0
+)
+RETURNS TABLE(challenge text, max_created_at timestamp with time zone)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT 
+    d.challenge,
+    MAX(d.created_at) as max_created_at
+  FROM derkap d
+  INNER JOIN derkap_allowed_users dau ON d.id = dau.derkap_id
+  WHERE dau.allowed_user_id = p_user_id
+    AND d.challenge IS NOT NULL
+    AND d.challenge != ''
+  GROUP BY d.challenge
+  ORDER BY MAX(d.created_at) DESC
+  LIMIT p_limit
+  OFFSET p_offset;
+$$;
+
+-- Grant necessary permissions
+GRANT ALL ON FUNCTION "public"."get_user_allowed_challenges"("uuid", integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_user_allowed_challenges"("uuid", integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_user_allowed_challenges"("uuid", integer, integer) TO "service_role";


### PR DESCRIPTION
Add a challenge selector to the feed to filter derkaps by unique challenge text with pagination.

This feature allows users to select a specific challenge from a dropdown, which then filters their feed to show only derkaps related to that challenge. It includes pagination for both fetching the list of unique challenges and the derkaps within a selected challenge, improving navigation and performance for users with many derkaps.

---
<a href="https://cursor.com/background-agent?bcId=bc-58f9829b-1bd5-408f-8cbb-eb498598f55f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-58f9829b-1bd5-408f-8cbb-eb498598f55f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>